### PR TITLE
BUG: Introduce one-day shift in "today" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 23/06/22
+
+BUG: Introduce one-day shift in "today" option
+to download positions
+
 ## [0.3.0] - 22/06/22
 
 ENH, TST: Create positions database

--- a/src/degiro_wrapper/cli/cli.py
+++ b/src/degiro_wrapper/cli/cli.py
@@ -38,6 +38,9 @@ def download_positions(from_, to, path):
     click.echo("Downloading positions ...")
 
     today = pd.to_datetime(to).date()
+    # Degiro provides updated positions with one-day lag
+    if to == "today":
+        today = today - pd.offsets.BDay(1)
     calendar = pd.date_range(freq="B", start=from_, end=today)
 
     start = calendar[0].strftime("%Y-%M-%d")


### PR DESCRIPTION
When we download positions, we cannot use today's date, since the prices will not be updated.