### PR TITLE
enh(report): avoid parse spaces when it reads a csv

### DIFF
--- a/src/degiro_wrapper/cli/report.py
+++ b/src/degiro_wrapper/cli/report.py
@@ -11,7 +11,10 @@ from degiro_wrapper.reporting.calculations import (
     compute_tna,
 )
 from degiro_wrapper.reporting.plot import create_report_plots
-from degiro_wrapper.reporting.utils import filter_positions, filter_transactions
+from degiro_wrapper.reporting.utils import (
+    filter_positions,
+    filter_transactions,
+)
 
 from .cli import cli
 
@@ -79,9 +82,18 @@ def report(path_ps, path_tr, path_pf, start, end, path_rp):
 
     # -------------------------------------------------------------------------
     # Read data
-    positions = pd.read_csv(path_ps, index_col=0, parse_dates=[Positions.DATE])
-    transactions = pd.read_csv(path_tr, parse_dates=[Transactions.DATE])
-    portfolio = pd.read_csv(path_pf, index_col=Positions.ISIN)
+    positions = pd.read_csv(
+        path_ps,
+        index_col=0,
+        skipinitialspace=True,
+        parse_dates=[Positions.DATE],
+    )
+    transactions = pd.read_csv(
+        path_tr, skipinitialspace=True, parse_dates=[Transactions.DATE]
+    )
+    portfolio = pd.read_csv(
+        path_pf, skipinitialspace=True, index_col=Positions.ISIN
+    )
 
     # -------------------------------------------------------------------------
     # Parse period


### PR DESCRIPTION
If you have a file like:

    index,colA   ,    colB
    0    ,value a, value b
    1    ,value a, value b

the read_csv function creates an dataframe with the following columns:

    Index(["index", "colA   ", "    colB"])

which is unexpected (at least to me). With this change the columns will
be:

    Index(["index", "colA", "colB"])